### PR TITLE
Transaction status retry count implemented

### DIFF
--- a/src/main/java/org/mifos/connector/mpesa/camel/config/CamelProperties.java
+++ b/src/main/java/org/mifos/connector/mpesa/camel/config/CamelProperties.java
@@ -15,4 +15,7 @@ public class CamelProperties {
     public static final String STATUS_AVAILABLE = "statusAvailable";
     public static final String TRANSACTION_STATUS = "transactionStatus";
     public static final String MPESA_API_REQUEST_FAILED = "mpesaApiCallFailed";
+    public static final String IS_RETRY_EXCEEDED = "isRetryExceeded";
+    public static final String IS_TRANSACTION_PENDING = "isTransactionPending";
+    public static final String ZEEBE_ELEMENT_INSTANCE_KEY = "elementInstanceKey";
 }

--- a/src/main/java/org/mifos/connector/mpesa/camel/config/CamelProperties.java
+++ b/src/main/java/org/mifos/connector/mpesa/camel/config/CamelProperties.java
@@ -18,4 +18,9 @@ public class CamelProperties {
     public static final String IS_RETRY_EXCEEDED = "isRetryExceeded";
     public static final String IS_TRANSACTION_PENDING = "isTransactionPending";
     public static final String ZEEBE_ELEMENT_INSTANCE_KEY = "elementInstanceKey";
+    public static final String MPESA_API_RESPONSE = "mpesaApiResponse";
+    public static final String OPERATIONS_FILTER_BY = "operationsFilterBy";
+    public static final String OPERATIONS_FILTER_VALUE = "operationsFilterValue";
+    public static final String ERROR_CODE = "errorCode";
+    public static final String IS_ERROR_RECOVERABLE = "isErrorRecoverable";
 }

--- a/src/main/java/org/mifos/connector/mpesa/camel/config/OperationsProperties.java
+++ b/src/main/java/org/mifos/connector/mpesa/camel/config/OperationsProperties.java
@@ -1,0 +1,10 @@
+package org.mifos.connector.mpesa.camel.config;
+
+public class OperationsProperties {
+
+    public static String FILTER_BY_RECOVERABLE = "recoverable";
+    public static String FILTER_BY_TRANSACTION_TYPE = "transactionType";
+    public static String FILTER_BY_ERROR_CODE = "errorCode";
+
+
+}

--- a/src/main/java/org/mifos/connector/mpesa/camel/routes/OperationsRoute.java
+++ b/src/main/java/org/mifos/connector/mpesa/camel/routes/OperationsRoute.java
@@ -34,19 +34,22 @@ public class OperationsRoute extends RouteBuilder {
                 .id("filter-by-error-codes")
                 .log(LoggingLevel.INFO, "### Starting FILTER-BY-ERROR-CODE route")
                 .toD(getFilterUrl(FILTER_BY_ERROR_CODE, exchangeProperty(OPERATIONS_FILTER_VALUE)))
-                .log(LoggingLevel.INFO, "Operations response: \n\n.. ${body}");
+                .log(LoggingLevel.INFO, "Operations response: \n\n.. ${body}")
+                .to("direct:filter-response-handler");
 
         from("direct:get-recoverable-error-codes")
                 .id("get-recoverable-error-codes")
                 .log(LoggingLevel.INFO, "### Starting GET-RECOVERABLE-CODES route")
                 .toD(getFilterUrl(FILTER_BY_RECOVERABLE, true))
-                .log(LoggingLevel.INFO, "Operations response: \n\n.. ${body}");
+                .log(LoggingLevel.INFO, "Operations response: \n\n.. ${body}")
+                .to("direct:filter-response-handler");
 
         from("direct:get-non-recoverable-error-codes")
                 .id("get-non-recoverable-error-codes")
                 .log(LoggingLevel.INFO, "### Starting GET-NON-RECOVERABLE-CODES route")
                 .toD(getFilterUrl(FILTER_BY_RECOVERABLE, false))
-                .log(LoggingLevel.INFO, "Operations response: \n\n.. ${body}");
+                .log(LoggingLevel.INFO, "Operations response: \n\n.. ${body}")
+                .to("direct:filter-response-handler");
 
         from("direct:filter-response-handler")
                 .id("filter-response-handler")

--- a/src/main/java/org/mifos/connector/mpesa/camel/routes/OperationsRoute.java
+++ b/src/main/java/org/mifos/connector/mpesa/camel/routes/OperationsRoute.java
@@ -1,0 +1,65 @@
+package org.mifos.connector.mpesa.camel.routes;
+
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.dataformat.JsonLibrary;
+import org.apache.camel.util.json.JsonArray;
+import org.mifos.connector.mpesa.flowcomponents.transaction.ErrorProcessor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import static org.mifos.connector.mpesa.camel.config.CamelProperties.OPERATIONS_FILTER_VALUE;
+import static org.mifos.connector.mpesa.camel.config.OperationsProperties.FILTER_BY_ERROR_CODE;
+import static org.mifos.connector.mpesa.camel.config.OperationsProperties.FILTER_BY_RECOVERABLE;
+
+@Component
+public class OperationsRoute extends RouteBuilder {
+
+    @Value("${operations.host}")
+    private String operationsHost;
+
+    @Value("${operations.base-url}")
+    private String operationsBaseUrl;
+
+    @Value("${operations.filter-path}")
+    private String operationsFilterPath;
+
+    @Autowired
+    private ErrorProcessor errorProcessor;
+
+    @Override
+    public void configure() throws Exception {
+
+        from("direct:filter-by-error-code")
+                .id("filter-by-error-codes")
+                .log(LoggingLevel.INFO, "### Starting FILTER-BY-ERROR-CODE route")
+                .toD(getFilterUrl(FILTER_BY_ERROR_CODE, exchangeProperty(OPERATIONS_FILTER_VALUE)))
+                .log(LoggingLevel.INFO, "Operations response: \n\n.. ${body}");
+
+        from("direct:get-recoverable-error-codes")
+                .id("get-recoverable-error-codes")
+                .log(LoggingLevel.INFO, "### Starting GET-RECOVERABLE-CODES route")
+                .toD(getFilterUrl(FILTER_BY_RECOVERABLE, true))
+                .log(LoggingLevel.INFO, "Operations response: \n\n.. ${body}");
+
+        from("direct:get-non-recoverable-error-codes")
+                .id("get-non-recoverable-error-codes")
+                .log(LoggingLevel.INFO, "### Starting GET-NON-RECOVERABLE-CODES route")
+                .toD(getFilterUrl(FILTER_BY_RECOVERABLE, false))
+                .log(LoggingLevel.INFO, "Operations response: \n\n.. ${body}");
+
+        from("direct:filter-response-handler")
+                .id("filter-response-handler")
+                .unmarshal().json(JsonLibrary.Jackson, JsonArray.class)
+                .log(LoggingLevel.INFO, "### Starting FILTER-RESPONSE-HANDLER route")
+                .process(errorProcessor);
+
+    }
+
+    private String getFilterUrl(String filterBy, Object filterValue) {
+        String url = operationsHost + operationsBaseUrl + operationsFilterPath;
+        String params = String.format("?by=%s&value=%s&", filterBy, filterValue);
+        String internalParams = "bridgeEndpoint=true&throwExceptionOnFailure=false";
+        return url + params + internalParams;
+    }
+}

--- a/src/main/java/org/mifos/connector/mpesa/flowcomponents/mpesa/MpesaGenericProcessor.java
+++ b/src/main/java/org/mifos/connector/mpesa/flowcomponents/mpesa/MpesaGenericProcessor.java
@@ -1,0 +1,17 @@
+package org.mifos.connector.mpesa.flowcomponents.mpesa;
+
+import org.apache.camel.Exchange;
+import org.springframework.stereotype.Component;
+import org.apache.camel.Processor;
+
+import static org.mifos.connector.mpesa.camel.config.CamelProperties.MPESA_API_RESPONSE;
+
+@Component
+public class MpesaGenericProcessor implements Processor {
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        exchange.setProperty(MPESA_API_RESPONSE, exchange.getIn().getBody(String.class));
+    }
+
+}

--- a/src/main/java/org/mifos/connector/mpesa/flowcomponents/transaction/ErrorProcessor.java
+++ b/src/main/java/org/mifos/connector/mpesa/flowcomponents/transaction/ErrorProcessor.java
@@ -1,0 +1,26 @@
+package org.mifos.connector.mpesa.flowcomponents.transaction;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.springframework.stereotype.Component;
+import static org.mifos.connector.mpesa.camel.config.CamelProperties.IS_ERROR_RECOVERABLE;
+import static org.mifos.connector.mpesa.camel.config.OperationsProperties.FILTER_BY_RECOVERABLE;
+
+@Component
+public class ErrorProcessor implements Processor {
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        JsonArray response = exchange.getIn().getBody(JsonArray.class);
+
+        if(response.size() == 0) {
+            exchange.setProperty(IS_ERROR_RECOVERABLE, false);
+            return;
+        }
+
+        JsonObject errorCodeObject = (JsonObject) response.get(0);
+        Boolean recoverable = errorCodeObject.getBoolean(FILTER_BY_RECOVERABLE);
+        exchange.setProperty(IS_ERROR_RECOVERABLE, recoverable);
+    }
+}

--- a/src/main/java/org/mifos/connector/mpesa/zeebe/ZeebeVariables.java
+++ b/src/main/java/org/mifos/connector/mpesa/zeebe/ZeebeVariables.java
@@ -7,6 +7,7 @@ public class ZeebeVariables {
     public static final String TRANSACTION_ID = "transactionId";
     public static final String SERVER_TRANSACTION_ID = "mpesaTransactionId";
     public static final String SERVER_TRANSACTION_RECEIPT_NUMBER = "mpesaReceiptNumber";
+    public static final String SERVER_TRANSACTION_STATUS_RETRY_COUNT = "mpesaTransactionStatusRetryCount";
     public static final String TRANSACTION_FAILED = "transactionFailed";
     public static final String TRANSFER_MESSAGE = "transaction-request";
     public static final String TRANSFER_RETRY_COUNT = "paymentTransferRetry";

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,11 @@ zeebe:
   broker:
     contactpoint: "localhost:26500"
 
+operations:
+  host: https://paymenthub.qa.oneacrefund.org/opsapp
+  base-url: /api/v1/errorcode
+  filter-path: /filter
+
 mpesa:
   business-short-code: 7385028
   till: 1234567

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,7 @@ zeebe:
 mpesa:
   business-short-code: 7385028
   till: 1234567
+  max-retry-count: 3
   local:
     host: http://localhost:5000
     transaction-callback: /buygoods/callback


### PR DESCRIPTION
Now the transaction status logic is retried for a set number of times before failing and it is decided by a  configuration field named mpesa.max-retry-count.