### PR TITLE
Minor Fix for setting correct AMS name at runtime

### DIFF
--- a/src/main/java/org/mifos/connector/mpesa/auth/AuthRoutes.java
+++ b/src/main/java/org/mifos/connector/mpesa/auth/AuthRoutes.java
@@ -38,8 +38,8 @@ public class AuthRoutes extends RouteBuilder {
 
     @Override
     public void configure() {
-        mpesaProps = mpesautils.getMpesaProperties();
-
+        mpesaProps = mpesautils.setMpesaProperties();
+        logger.info("AMS Name set by configure" + mpesaProps.getName());
         /*
           Error handling route
          */
@@ -72,15 +72,13 @@ public class AuthRoutes extends RouteBuilder {
                 .id("access-token-fetch")
                 .log(LoggingLevel.INFO, "Fetching access token")
                 .removeHeader(Exchange.HTTP_PATH)
+                .process(exchange -> {
+                    mpesaProps = mpesautils.setMpesaProperties();
+                    logger.info("AMS Name in Route " + mpesaProps.getName());
+                })
                 .setHeader(Exchange.HTTP_METHOD, constant("GET"))
                 .setHeader("Authorization", simple("Basic " + createAuthHeader(mpesaProps.getClientKey(),mpesaProps.getClientSecret())))
                 .setHeader(Exchange.HTTP_RAW_QUERY, constant("grant_type=client_credentials"))
-                /*.process(exchange -> {
-                    logger.info("\nClient key: " + clientKey);
-                    logger.info("\nSecret key: " + clientSecret);
-                    logger.info("\nBasic " + createAuthHeader(clientKey, clientSecret));
-                    logger.info("\nURL: " + authUrl);
-                })*/
                 .toD(mpesaProps.getAuthHost() + "?bridgeEndpoint=true" + "&" +
                         "throwExceptionOnFailure=false&" + ConnectionUtils.getConnectionTimeoutDsl(mpesaTimeout));
 

--- a/src/main/java/org/mifos/connector/mpesa/camel/routes/SafaricomRoutesBuilder.java
+++ b/src/main/java/org/mifos/connector/mpesa/camel/routes/SafaricomRoutesBuilder.java
@@ -83,12 +83,13 @@ public class SafaricomRoutesBuilder extends RouteBuilder {
 
     @Override
     public void configure() {
-
+        mpesaProps = mpesaUtils.setMpesaProperties();
+        logger.info("AMS Name set by configure" + mpesaProps.getName());
         /*
          * Use this endpoint for getting the mpesa transaction status
          * The request parameter is same as the safaricom standards
          */
-        mpesaProps = mpesaUtils.getMpesaProperties();
+
         from("rest:POST:/buygoods/transactionstatus")
                 .id("buy-goods-transaction-status")
                 .process(exchange -> {
@@ -326,6 +327,10 @@ public class SafaricomRoutesBuilder extends RouteBuilder {
                 .setHeader("Content-Type", constant("application/json"))
                 .setHeader("Authorization", simple("Bearer ${exchangeProperty."+ACCESS_TOKEN+"}"))
                 .setBody(exchange -> {
+                    mpesaProps = mpesaUtils.setMpesaProperties();
+                    logger.info("AMS Name in Route " + mpesaProps.getName());
+                    logger.info("Values from safaricome routebuilder: Shortcode - " + mpesaProps.getBusinessShortCode() + " Till -" +
+                            mpesaProps.getTill());
                     BuyGoodsPaymentRequestDTO buyGoodsPaymentRequestDTO =
                             (BuyGoodsPaymentRequestDTO) exchange.getProperty(BUY_GOODS_REQUEST_BODY);
 

--- a/src/main/java/org/mifos/connector/mpesa/utility/MpesaUtils.java
+++ b/src/main/java/org/mifos/connector/mpesa/utility/MpesaUtils.java
@@ -29,7 +29,7 @@ public class MpesaUtils {
        return mpesa;
     }
 
-    public MpesaProps.MPESA getMpesaProperties(){
+    public MpesaProps.MPESA setMpesaProperties(){
         MpesaProps.MPESA properties = null;
         List<MpesaProps.MPESA> groups = getGroup();
         for(MpesaProps.MPESA identifier : groups){

--- a/src/main/java/org/mifos/connector/mpesa/utility/SafaricomUtils.java
+++ b/src/main/java/org/mifos/connector/mpesa/utility/SafaricomUtils.java
@@ -44,7 +44,7 @@ public class SafaricomUtils {
     public BuyGoodsPaymentRequestDTO channelRequestConvertor(TransactionChannelC2BRequestDTO transactionChannelRequestDTO) {
         logger.info("TransactionChannelCollectionRequestDTO chile converting " + transactionChannelRequestDTO);
         BuyGoodsPaymentRequestDTO buyGoodsPaymentRequestDTO = new BuyGoodsPaymentRequestDTO();
-        mpesaProps = mpesaUtils.getMpesaProperties();
+        mpesaProps = mpesaUtils.setMpesaProperties();
 
         long amount = Long.parseLong(transactionChannelRequestDTO.getAmount().getAmount().trim());
         long timestamp = getTimestamp(); //123; //Long.parseLong(sdf.format(new Date()));
@@ -77,7 +77,8 @@ public class SafaricomUtils {
         buyGoodsPaymentRequestDTO.setTransactionDesc("Payment from account id" +
                 transactionChannelRequestDTO.getPayer()[1].getValue());
         buyGoodsPaymentRequestDTO.setAccountReference("Payment to " + mpesaProps.getBusinessShortCode());
-
+        logger.info("Values from Safaricom utils: Shortcode - " + mpesaProps.getBusinessShortCode() + " Till -" +
+                mpesaProps.getTill());
 
         return buyGoodsPaymentRequestDTO;
     }


### PR DESCRIPTION
This commit  has 

1.  Fix for picking AMS name in route 

 - During service startup default value was being used to set up routes, these values were not getting overwritten by AMS specific values that would have been based on the workflow being executed. 
 - This did not affect values like shortcode and till number because they were getting set independent of any camel route, but values like client key client secret that were specific to camel route execution were not getting overwritten.
 - So added the method that fetched the AMS specific data based on the process name inside the route.
 
2. Changed ambiguous method name that was setting property value based on process name from getMpesaProperties to setMpesaProperties

3.  Added additional log statements


@avikganguly01 : Please review 